### PR TITLE
Fixes #10. Copy plugin configuration to all executions without a configuration.

### DIFF
--- a/tiles-maven-plugin/src/main/java/it/session/maven/plugin/TilesModelMerger.java
+++ b/tiles-maven-plugin/src/main/java/it/session/maven/plugin/TilesModelMerger.java
@@ -1,11 +1,14 @@
 package it.session.maven.plugin;
 
-import org.apache.maven.model.Model;
-import org.apache.maven.model.Plugin;
-import org.apache.maven.model.merge.ModelMerger;
-
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.model.merge.ModelMerger;
 
 /**
  * TilesModelMerger by-passes the invocation to ModelMerger.merge() by adding the merge of Plugin configuration.
@@ -27,6 +30,13 @@ public class TilesModelMerger extends ModelMerger {
       for(Plugin sourcePlugin : source.getBuild().getPlugins()) {
         Plugin targetPlugin = target.getBuild().getPluginsAsMap().get(sourcePlugin.getKey());
         super.mergePlugin(targetPlugin, sourcePlugin, sourceDominant, context);
+        Set<Entry<String, PluginExecution>> entrySet = targetPlugin.getExecutionsAsMap().entrySet();
+        for (Entry<String, PluginExecution> entry : entrySet) {
+          PluginExecution execution = entry.getValue();
+          if (execution.getConfiguration() == null) {
+            execution.setConfiguration(sourcePlugin.getConfiguration());
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
I'm not sure why `plugin.configuration` is not passed to plugins (and `plugin.executions.execution.configuration` is). This might be a maven bug.
Here is some random method that uses `Plugin.getConfiguration` like `MavenProject.getGoalConfiguration`:

```
dom = (Xpp3Dom) plugin.getConfiguration();

if ( executionId != null )
{
    PluginExecution execution = plugin.getExecutionsAsMap().get( executionId );
    if ( execution != null )
    {
        // NOTE: The PluginConfigurationExpander already merged the plugin-level config in
        dom = (Xpp3Dom) execution.getConfiguration();
    }
}
```

It looks that putting `plugin.configuration` in `plugin.executions.execution.configuration` when it's `null`, is consistent with maven expectations.
